### PR TITLE
Q&D workaround for ubuntu 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,16 @@
-FROM accetto/ubuntu-vnc-xfce-chromium-g3
+FROM registry.forge.inrae.fr/teledec/ubuntu-qgis-vnc:latest-chromium
 
 USER root
 
-RUN apt-get update -y && \
-    apt-get upgrade -y && \
-    apt-get install -y apt-utils apt-transport-https software-properties-common gnupg curl iputils-ping vim libnss3-tools ssh git unzip && \
-    apt-get update
-
 # Get Onyxia init script
-RUN wget https://raw.githubusercontent.com/InseeFrLab/images-datascience/main/base/common-scripts/onyxia-init.sh -O /opt/onyxia-init.sh && \
+RUN wget https://raw.githubusercontent.com/InseeFrLab/images-datascience/refs/heads/main/base/scripts/onyxia-init.sh -O /opt/onyxia-init.sh && \
     chmod +x /opt/onyxia-init.sh
 
-##### Extension JsonViewer pour chromium
-RUN touch /etc/chromium-browser/policies/managed/test_policy.json && \
-    echo "{\"ExtensionInstallForcelist\": [\"aimiinbnnkboelefkjlenlgimcabobli;https://clients2.google.com/service/update2/crx\"]}" > /etc/chromium-browser/policies/managed/test_policy.json
-
 # Installing mc
-
 RUN wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc && \
     chmod +x /usr/local/bin/mc
 
-
 # Installing vault
-
 RUN cd /usr/bin && \
     wget https://releases.hashicorp.com/vault/1.8.2/vault_1.8.2_linux_amd64.zip && \
     unzip vault_1.8.2_linux_amd64.zip && \
@@ -30,33 +18,14 @@ RUN cd /usr/bin && \
 RUN vault -autocomplete-install
 
 # Installing kubectl
-
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl
-RUN apt-get install bash-completion
 
 # Installing helm
-
 RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 && \
     chmod 700 get_helm.sh && \
     ./get_helm.sh
-
-# Installing DBeaver
-RUN add-apt-repository ppa:serge-rider/dbeaver-ce && \
-    apt-get update  && \
-    apt-get install dbeaver-ce
-
-# Installing QGIS
-RUN mkdir -m755 -p /etc/apt/keyrings && \
-    wget -O /etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg && \
-    apt-get update && \
-    apt-get install -y qgis qgis-plugin-grass
-    
-# Clean
-RUN apt-get clean && \
-    apt -y autoremove && \
-    rm -rf /var/lib/apt/lists/*    
 
 ## Allow sudo without password
 RUN echo "headless     ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
@@ -72,5 +41,5 @@ ENV NOVNC_HEARTBEAT=30
 
 USER headless
 
-RUN mkdir /home/headless/work
 WORKDIR /home/headless/work
+


### PR DESCRIPTION
@olevitt as I mentioned yesterday on slack this is mostly a Q&D hack around acccetto's stuff, but we have ubuntu 24.04 with novnc and QGIS, which is what we needed.

We run it yeterday on onyxia, but I don't know how! I mean it was slow to start (we suspected too-strict readiness probes or something?), and picky to get up and running. Today I got http 503 errors.  

But it is running smoothly locally